### PR TITLE
fix: account index start from 1

### DIFF
--- a/index.js
+++ b/index.js
@@ -660,7 +660,7 @@ class LatticeKeyring extends EventEmitter {
         return {
           address,
           balance: null,
-          index: start + i,
+          index: start + i + 1,
         };
       });
       return accounts;


### PR DESCRIPTION
Checkout implementation of other keyrings, index should be start from 1

https://github.com/RabbyHub/eth-trezor-keyring/blob/main/index.ts#L230

https://github.com/RabbyHub/eth-hd-keyring/blob/main/index.ts#L138